### PR TITLE
Improvement/libz wrapper

### DIFF
--- a/common/include/s2e/function_models/s2e_so.h
+++ b/common/include/s2e/function_models/s2e_so.h
@@ -27,8 +27,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef S2E_LIBC_WRAPPER_H
-#define S2E_LIBC_WRAPPER_H
+#ifndef S2E_SO_H
+#define S2E_SO_H
 
 #include <s2e/function_models/models.h>
 

--- a/linux/function_models/libc_wrapper.c
+++ b/linux/function_models/libc_wrapper.c
@@ -24,8 +24,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <s2e/function_models/libc_wrapper.h>
 #include <s2e/function_models/models.h>
+#include <s2e/function_models/s2e_so.h>
 
 // ****************************
 // Overriding libc functions

--- a/linux/function_models/libz_wrapper.c
+++ b/linux/function_models/libz_wrapper.c
@@ -1,0 +1,46 @@
+/// S2E Selective Symbolic Execution Platform
+///
+/// Copyright (c) 2017 Adrian Herrera
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in all
+/// copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+/// SOFTWARE.
+
+#include <stdint.h>
+
+#include <s2e/function_models/libc_wrapper.h>
+#include <s2e/function_models/models.h>
+
+// ****************************
+// Overriding libz functions
+// ****************************
+
+uint32_t crc32(uint32_t crc, const uint8_t *buf, unsigned len) {
+    if (!g_enable_function_models) {
+        return (*orig_crc32)(crc, buf, len);
+    }
+
+    return crc32_model(crc, buf, len);
+}
+
+uint16_t crc16(uint16_t crc, const uint8_t *buf, unsigned len) {
+    if (!g_enable_function_models) {
+        return (*orig_crc16)(crc, buf, len);
+    }
+
+    return crc16_model(crc, buf, len);
+}

--- a/linux/function_models/libz_wrapper.c
+++ b/linux/function_models/libz_wrapper.c
@@ -22,8 +22,8 @@
 
 #include <stdint.h>
 
-#include <s2e/function_models/libc_wrapper.h>
 #include <s2e/function_models/models.h>
+#include <s2e/function_models/s2e_so.h>
 
 // ****************************
 // Overriding libz functions

--- a/linux/s2e.so/CMakeLists.txt
+++ b/linux/s2e.so/CMakeLists.txt
@@ -23,6 +23,7 @@
 
 add_library(s2e SHARED s2e.c
                        ../function_models/libc_wrapper.c
+                       ../function_models/libz_wrapper.c
                        ../function_models/models.c)
 target_link_libraries(s2e dl)
 set_target_properties(s2e PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/linux/s2e.so/s2e.c
+++ b/linux/s2e.so/s2e.c
@@ -38,7 +38,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <s2e/function_models/libc_wrapper.h>
+#include <s2e/function_models/s2e_so.h>
 #include <s2e/monitors/linux.h>
 #include <s2e/monitors/raw.h>
 #include <s2e/monitors/raw.h>


### PR DESCRIPTION
Hey @vitalych,

I have a student playing with file parsers in S2E; specifically PNG. The PNG file format uses CRC32 checksums and we wanted to try out the function model. However, I found that it was missing the correct `LD_PRELOAD` hooks, so I've added that (in libz_wrapper.c).

Since this uses the `g_enable_function_models` variable from libc_wrapper.h, I've renamed that header file (since it's now used by libc and libz) to s2e_so.h. I'm not sure if this is the most appropriate name, so if you have any other ideas I'm all ears!