### PR TITLE
s2ecmd: added feature to get seed file name in any state without forking

### DIFF
--- a/common/include/s2e/seed_searcher.h
+++ b/common/include/s2e/seed_searcher.h
@@ -58,6 +58,12 @@ static int s2e_seed_get_file(char *file, size_t bytes, int *should_fork) {
             ret = 0;
             *should_fork = 1;
             break;
+
+        /* Seed file available, start exploring it without fork*/
+        case 3:
+            ret = 0;
+            *should_fork = 0;
+            break;
     }
 
     return ret;

--- a/common/include/s2e/seed_searcher.h
+++ b/common/include/s2e/seed_searcher.h
@@ -48,25 +48,25 @@ static int s2e_seed_get_file(char *file, size_t bytes, int *should_fork) {
     int ret = 0;
     switch (cmd.GetFile.Result) {
         /* No seed file, other states exploring, no need to fork */
-        case 0:
+        case SEED_GETFILE_FAIL_NO_FORK:
             ret = -1;
             *should_fork = 0;
             break;
 
         /* No seed file, start exploration without seeds */
-        case 1:
+        case SEED_GETFILE_FAIL_DO_FORK:
             ret = -1;
             *should_fork = 1;
             break;
 
         /* Seed file available, start exploring it */
-        case 2:
+        case SEED_GETFILE_SUCC_DO_FORK:
             ret = 0;
             *should_fork = 1;
             break;
 
         /* Seed file available, start exploring it without fork*/
-        case 3:
+        case SEED_GETFILE_SUCC_NO_FORK:
             ret = 0;
             *should_fork = 0;
             break;

--- a/common/include/s2e/seed_searcher.h
+++ b/common/include/s2e/seed_searcher.h
@@ -64,6 +64,12 @@ static int s2e_seed_get_file(char *file, size_t bytes, int *should_fork) {
             ret = 0;
             *should_fork = 1;
             break;
+
+        /* Seed file available, start exploring it without fork*/
+        case 3:
+            ret = 0;
+            *should_fork = 0;
+            break;
     }
 
     return ret;

--- a/common/include/s2e/seed_searcher/commands.h
+++ b/common/include/s2e/seed_searcher/commands.h
@@ -35,6 +35,13 @@ enum S2E_SEEDSEARCHER_COMMANDS {
     SEED_DONE,
 };
 
+enum S2E_SEEDSEARCHER_GETFILE_RESULTS {
+    SEED_GETFILE_FAIL_NO_FORK,
+    SEED_GETFILE_FAIL_DO_FORK,
+    SEED_GETFILE_SUCC_DO_FORK,
+    SEED_GETFILE_SUCC_NO_FORK,
+};
+
 struct S2E_SEEDSEARCHER_COMMAND_GETFILE {
     /// Pointer to guest memory where the plugin will store the file name
     uint64_t FileName;

--- a/common/s2ecmd/s2ecmd.c
+++ b/common/s2ecmd/s2ecmd.c
@@ -359,6 +359,12 @@ static int handler_get_seed_file(int argc, const char **args) {
                 return 0;
             }
         }
+    } else {
+        if (ret == 0) {
+            s2e_message("Exploring using seed inputs");
+            printf("%s", seed_file);
+            return 0;
+        }
     }
 
     /* Keep looping */

--- a/common/s2ecmd/s2ecmd.cpp
+++ b/common/s2ecmd/s2ecmd.cpp
@@ -251,6 +251,12 @@ static int handler_get_seed_file(int argc, const char **args) {
                 return 0;
             }
         }
+    } else {
+        if (ret == 0) {
+            s2e_message("Exploring using seed inputs");
+            printf("%s", seed_file);
+            return 0;
+        }
     }
 
     /* Keep looping */


### PR DESCRIPTION
This added the guest support of retrieval of seed file name without forking, which can be used under single path   mode.