### PR TITLE
windows: fixed ETHREAD offset calculation

### DIFF
--- a/windows/driver/src/winmonitor_gen.c
+++ b/windows/driver/src/winmonitor_gen.c
@@ -98,7 +98,7 @@ static VOID Handler0x2247c2(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x120 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x168;
     Command.Structs.EThreadStackLimitOffset = 0x1c;
     Command.Structs.EThreadProcessOffset = 0x220;
@@ -173,7 +173,7 @@ static VOID Handler0x21a293(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x120 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x168;
     Command.Structs.EThreadStackLimitOffset = 0x1c;
     Command.Structs.EThreadProcessOffset = 0x220;
@@ -247,7 +247,7 @@ static VOID Handler0x3c88ac(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -320,7 +320,7 @@ static VOID Handler0x3c05d5(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -394,7 +394,7 @@ static VOID Handler0x55ce0c(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->CurrentPrcb;
 
     Command.Structs.EThreadSegment = R_GS;
-    Command.Structs.EThreadSegmentOffset = 0x180 + 0x8;
+    Command.Structs.EThreadSegmentOffset = 0x8;
     Command.Structs.EThreadStackBaseOffset = 0x278;
     Command.Structs.EThreadStackLimitOffset = 0x30;
     Command.Structs.EThreadProcessOffset = 0x210;
@@ -467,7 +467,7 @@ static VOID Handler0x3cbb94(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -540,7 +540,7 @@ static VOID Handler0x3cdec5(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -614,7 +614,7 @@ static VOID Handler0x556afe(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->CurrentPrcb;
 
     Command.Structs.EThreadSegment = R_GS;
-    Command.Structs.EThreadSegmentOffset = 0x180 + 0x8;
+    Command.Structs.EThreadSegmentOffset = 0x8;
     Command.Structs.EThreadStackBaseOffset = 0x278;
     Command.Structs.EThreadStackLimitOffset = 0x30;
     Command.Structs.EThreadProcessOffset = 0x210;
@@ -687,7 +687,7 @@ static VOID Handler0x3cca4b(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -760,7 +760,7 @@ static VOID Handler0x3cb498(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->Prcb;
 
     Command.Structs.EThreadSegment = R_FS;
-    Command.Structs.EThreadSegmentOffset = 0x20 + 0x4;
+    Command.Structs.EThreadSegmentOffset = 0x4;
     Command.Structs.EThreadStackBaseOffset = 0x190;
     Command.Structs.EThreadStackLimitOffset = 0x2c;
     Command.Structs.EThreadProcessOffset = 0x150;
@@ -834,7 +834,7 @@ static VOID Handler0x5546f7(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->CurrentPrcb;
 
     Command.Structs.EThreadSegment = R_GS;
-    Command.Structs.EThreadSegmentOffset = 0x180 + 0x8;
+    Command.Structs.EThreadSegmentOffset = 0x8;
     Command.Structs.EThreadStackBaseOffset = 0x278;
     Command.Structs.EThreadStackLimitOffset = 0x30;
     Command.Structs.EThreadProcessOffset = 0x210;
@@ -908,7 +908,7 @@ static VOID Handler0x71a4f4(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->CurrentPrcb;
 
     Command.Structs.EThreadSegment = R_GS;
-    Command.Structs.EThreadSegmentOffset = 0x180 + 0x8;
+    Command.Structs.EThreadSegmentOffset = 0x8;
     Command.Structs.EThreadStackBaseOffset = 0x38;
     Command.Structs.EThreadStackLimitOffset = 0x30;
     Command.Structs.EThreadProcessOffset = 0x220;
@@ -982,7 +982,7 @@ static VOID Handler0x7f010a(UINT_PTR KernelLoadBase, UINT_PTR KernelNativeBase)
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->CurrentPrcb;
 
     Command.Structs.EThreadSegment = R_GS;
-    Command.Structs.EThreadSegmentOffset = 0x180 + 0x8;
+    Command.Structs.EThreadSegmentOffset = 0x8;
     Command.Structs.EThreadStackBaseOffset = 0x38;
     Command.Structs.EThreadStackLimitOffset = 0x30;
     Command.Structs.EThreadProcessOffset = 0x220;

--- a/windows/scripts/gendriver.tpl
+++ b/windows/scripts/gendriver.tpl
@@ -80,11 +80,7 @@ static VOID Handler{{d.checksum | hex}}(UINT_PTR KernelLoadBase, UINT_PTR Kernel
     Command.Structs.KPRCB = (UINT_PTR) pKpcr->{{ 'CurrentPrcb' if d.bits == 64 else 'Prcb' }};
 
     Command.Structs.EThreadSegment = {{ 'R_GS' if d.bits == 64 else 'R_FS' }};
-    {% if d.version[0] == 5 -%}
-    Command.Structs.EThreadSegmentOffset = {{d._KPCR_PrcbData | hex}} + {{d._KPRCB_CurrentThread | hex}};
-    {% else -%}
-    Command.Structs.EThreadSegmentOffset = {{d._KPCR_Prcb | hex}} + {{d._KPRCB_CurrentThread | hex}};
-    {% endif -%}
+    Command.Structs.EThreadSegmentOffset = {{d._KPRCB_CurrentThread | hex}};
     Command.Structs.EThreadStackBaseOffset = {{d._KTHREAD_StackBase | hex}};
     Command.Structs.EThreadStackLimitOffset = {{d._KTHREAD_StackLimit | hex}};
     Command.Structs.EThreadProcessOffset = {{d._KTHREAD_Process | hex}};


### PR DESCRIPTION
The current thread offset calculation was generating incorrect results for 32-bit Windows versions > 5. This was because the incorrect` Prcb` offset was used in the `KPCR` struct (it should be `PrcbData`, not `Prcb` - see
https://www.geoffchappell.com/studies/windows/km/ntoskrnl/structs/kpcr.htm).

To fix this across all architectures and versions, calculate the correct offset in `WindowsMonitor` based on `Command.Structs.KPRCB`.

This PR goes with https://github.com/S2E/libs2eplugins/pull/43