### PR TITLE
fix opcode

### DIFF
--- a/windows/libcommon/src/amd64/s2e.asm
+++ b/windows/libcommon/src/amd64/s2e.asm
@@ -107,8 +107,8 @@ S2EGetConstraintCount endp
 public S2EConcretize
 S2EConcretize proc frame ; _Buffer: near ptr dword, _Size: dword
     .endprolog
-    ;mov rcx, rcx
-    mov rax, rdx
+    mov rax, rcx  ; _Buffer
+    ;mov edx, edx ; _Size
     db 0fh, 3fh
     db 00h, 20h, 00h, 00h
     db 00h, 00h, 00h, 00h

--- a/windows/libcommon/src/i386/s2e.asm
+++ b/windows/libcommon/src/i386/s2e.asm
@@ -96,8 +96,8 @@ S2EGetConstraintCount endp
 
 public S2EConcretize
 S2EConcretize proc near _Buffer: near ptr dword, _Size: dword
-    mov ecx, _Buffer
-    mov eax, _Size
+    mov eax, _Buffer
+    mov edx, _Size
     db 0fh, 3fh
     db 00h, 20h, 00h, 00h
     db 00h, 00h, 00h, 00h


### PR DESCRIPTION
Looking at [1] it seems that the input registers of S2EConcretize are wrong. In particular: 
- _ecx_ for the buffer (in place of _eax_) 
- _eax_ for the size (in place of _edx_)

[1] https://github.com/S2E/libs2eplugins/blob/master/src/s2e/Plugins/Core/BaseInstructions.cpp#L407

Signed-off-by: Luca Borzacchiello <lucaborza@gmail.com>